### PR TITLE
Use write_all instead of write in examples

### DIFF
--- a/examples/test_client.rs
+++ b/examples/test_client.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), HandshakeError> {
     v.extend_from_slice(&o.read_noncegen.next()[..]);
     assert_eq!(v.len(), 112);
 
-    stdout().write(&v).unwrap();
+    stdout().write_all(&v).unwrap();
     stdout().flush().unwrap();
 
     Ok(())

--- a/examples/test_server.rs
+++ b/examples/test_server.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), HandshakeError> {
     v.extend_from_slice(&o.read_noncegen.next()[..]);
     assert_eq!(v.len(), 112);
 
-    stdout().write(&v).unwrap();
+    stdout().write_all(&v).unwrap();
     stdout().flush().unwrap();
 
     Ok(())


### PR DESCRIPTION
write isnt guaranteed to process the entire buffer, while write_all is.
That's what we want so, use it.